### PR TITLE
23_eduArdu_Joystick.ino: Joystick as arrow keys

### DIFF
--- a/SOFTWARE/23_eduArdu_Joystick/23_eduArdu_Joystick.ino
+++ b/SOFTWARE/23_eduArdu_Joystick/23_eduArdu_Joystick.ino
@@ -1,0 +1,48 @@
+#include<Keyboard.h>
+
+// Analog input of the horizontal joystick position
+const int JoystickX = A0;
+// Analog input of the vertical joystick position
+const int JoystickY = A1;
+
+void setup()
+{
+
+}
+
+void loop()
+{
+  // Process horizontal joystick position
+  int x = analogRead(JoystickX);
+  if (1023 == x)
+  {
+    Keyboard.press(KEY_RIGHT_ARROW);
+  }
+  else if (0 == x)
+  {
+    Keyboard.press(KEY_LEFT_ARROW);
+  }
+  else
+  {
+    Keyboard.release(KEY_RIGHT_ARROW);
+    Keyboard.release(KEY_LEFT_ARROW);
+    delay(10);
+  }
+
+  // Process vertical joystick position
+  int y = analogRead(JoystickY);
+  if (1023 == y)
+  {
+    Keyboard.press(KEY_UP_ARROW);
+  }
+  else if (0 == y)
+  {
+    Keyboard.press(KEY_DOWN_ARROW);
+  }
+  else
+  {
+    Keyboard.release(KEY_UP_ARROW);
+    Keyboard.release(KEY_DOWN_ARROW);
+    delay(10);
+  }
+}


### PR DESCRIPTION
Example implementation that emulates keyboard arrow keys when the
joystick is pressed in the appropaite direction. Useful for using
eduArdu as a super simple USB HID gamepad for games like 2048.

Signed-off-by: Leon Anavi <leon@anavi.org>